### PR TITLE
chore(deps/api): use python 3.12

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.12
 
 WORKDIR /app
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0-or-later"
 readme = "../README.md"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.12"
 django = "^4.2.6"
 django-environ = "^0.9.0"
 psycopg2-binary = "^2.9.9"


### PR DESCRIPTION
usecase: `pathlib.Path.walk` in Tracker #43 