### PR TITLE
Make EOL Dates editable

### DIFF
--- a/ember/app/components/dependency-detailed/component.js
+++ b/ember/app/components/dependency-detailed/component.js
@@ -1,0 +1,35 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { dropTask } from 'ember-concurrency';
+
+import ReleaseVersionValidations from 'outdated/validations/release-version';
+
+export default class DependencyDetailedComponent extends Component {
+  @service notification;
+
+  ReleaseVersionValidations = ReleaseVersionValidations;
+
+  @tracked editing = false;
+
+  constructor(...args) {
+    super(...args);
+    this.args.version.endOfLifeDate = this.args.version.endOfLife;
+  }
+
+  saveReleaseVersion = dropTask(async (data) => {
+    try {
+      const changes = await data.changes;
+      if (changes.length) {
+        const releaseVersion = this.args.version.releaseVersion;
+        releaseVersion.endOfLife = changes[0].value;
+        await releaseVersion.save();
+      }
+
+      this.editing = false;
+    } catch (e) {
+      this.notification.danger(e);
+      console.error(e);
+    }
+  });
+}

--- a/ember/app/components/dependency-detailed/template.hbs
+++ b/ember/app/components/dependency-detailed/template.hbs
@@ -5,10 +5,37 @@
   <td data-test-version-version>
     {{@version.version}}
   </td>
-  <td data-test-version-end-of-life>
+  <td
+    role="button"
+    {{on "click" (fn (mut this.editing) true)}}
+    data-test-version-end-of-life
+  >
     {{or (format-date @version.endOfLife) "missing"}}
   </td>
   <td data-test-version-release-date>
     {{format-date @version.releaseDate}}
   </td>
 </tr>
+<Modal @title={{@version.releaseVersion.name}} @visible={{this.editing}} as |m|>
+  <Form
+    @model={{changeset @version this.ReleaseVersionValidations}}
+    @onSubmit={{perform this.saveReleaseVersion}}
+    as |f|
+  >
+    <m.body>
+      <f.input @name="endOfLifeDate" @type="date" />
+    </m.body>
+    <m.footer class="uk-flex uk-flex-between">
+      <f.button
+        @loading={{this.saveReleaseVersion.running}}
+        @disabled={{this.saveReleaseVersion.running}}
+      />
+      <UkButton
+        @type="button"
+        @label="cancel"
+        @color="danger"
+        @onClick={{fn (mut this.editing) false}}
+      />
+    </m.footer>
+  </Form>
+</Modal>

--- a/ember/app/components/validated-input/types/date/component.js
+++ b/ember/app/components/validated-input/types/date/component.js
@@ -1,6 +1,14 @@
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
+
 export default class DateInputComponent extends Component {
+  @service intl;
+
+  get locale() {
+    return this.intl.primaryLocale.split('-')[0];
+  }
+
   @action
   onUpdate(value) {
     this.args.update(value[0]);

--- a/ember/app/components/validated-input/types/date/template.hbs
+++ b/ember/app/components/validated-input/types/date/template.hbs
@@ -1,6 +1,7 @@
 <EmberFlatpickr
   placeholder={{@placeholder}}
   @dateFormat={{or @dateFormat "Y-m-d"}}
+  @locale={{this.locale}}
   @date={{or @value null}}
   @onChange={{this.onUpdate}}
   @onClose={{@setDirty}}

--- a/ember/app/models/release-version.js
+++ b/ember/app/models/release-version.js
@@ -4,7 +4,7 @@ export default class ReleaseVersionModel extends Model {
   @attr majorVersion;
   @attr minorVersion;
   @attr status;
-  @attr latestPatchVersion;
+
   @attr('django-date') endOfLife;
   @belongsTo('dependency', { inverse: null, async: false }) dependency;
 

--- a/ember/app/models/version.js
+++ b/ember/app/models/version.js
@@ -1,4 +1,5 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
+import { tracked } from '@glimmer/tracking';
 
 export default class VersionModel extends Model {
   @attr patchVersion;
@@ -8,6 +9,7 @@ export default class VersionModel extends Model {
   get name() {
     return this.releaseVersion.get('dependency.name');
   }
+
   get endOfLife() {
     return this.releaseVersion.get('endOfLife');
   }
@@ -21,4 +23,6 @@ export default class VersionModel extends Model {
   get status() {
     return this.releaseVersion.get('status');
   }
+
+  @tracked endOfLifeDate;
 }

--- a/ember/app/routes/application.js
+++ b/ember/app/routes/application.js
@@ -7,6 +7,6 @@ export default class ApplicationRoute extends Route {
 
   async beforeModel() {
     await this.session.setup();
-    this.intl.setLocale(['en-us']);
+    this.intl.setLocale(['de-ch']);
   }
 }

--- a/ember/app/transforms/django-date.js
+++ b/ember/app/transforms/django-date.js
@@ -1,4 +1,5 @@
 import Transform from '@ember-data/serializer/transform';
+import { DateTime } from 'luxon';
 
 export default class DjangoDateTransform extends Transform {
   deserialize(serialized) {
@@ -7,7 +8,7 @@ export default class DjangoDateTransform extends Transform {
 
   serialize(deserialized) {
     return deserialized instanceof Date
-      ? deserialized.toISOString().slice(0, 10)
+      ? DateTime.fromJSDate(deserialized).toISODate()
       : null;
   }
 }

--- a/ember/app/validations/release-version.js
+++ b/ember/app/validations/release-version.js
@@ -1,0 +1,9 @@
+import { validatePresence } from 'ember-changeset-validations/validators';
+
+import validateDate from '../validators/other-date';
+export default {
+  endOfLifeDate: [
+    validatePresence({ presence: true, ignoreBlank: true }),
+    validateDate({ after: 'releaseDate' }),
+  ],
+};

--- a/ember/ember-cli-build.js
+++ b/ember/ember-cli-build.js
@@ -4,6 +4,9 @@ const BrotliPlugin = require('brotli-webpack-plugin');
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
+    flatpickr: {
+      locales: ['de', 'fr'],
+    },
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },

--- a/ember/tests/integration/components/form-test.js
+++ b/ember/tests/integration/components/form-test.js
@@ -2,6 +2,7 @@ import { render, fillIn, triggerEvent } from '@ember/test-helpers';
 import Changeset from 'ember-changeset';
 import lookupValidator from 'ember-changeset-validations';
 import { hbs } from 'ember-cli-htmlbars';
+import { setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
 import { setupRenderingTest } from 'outdated/tests/helpers';
@@ -9,6 +10,7 @@ import TestValidations from 'outdated/tests/validations/test';
 
 module('Integration | Component | form', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   test('it renders a normal input', async function (assert) {
     await render(hbs`<Form as |f|> <f.input @name='test' /> </Form>`);

--- a/ember/tests/integration/components/validated-input/types/date-test.js
+++ b/ember/tests/integration/components/validated-input/types/date-test.js
@@ -1,5 +1,6 @@
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
 import { setupRenderingTest } from 'outdated/tests/helpers';
@@ -7,6 +8,7 @@ module(
   'Integration | Component | validated-input/types/date',
   function (hooks) {
     setupRenderingTest(hooks);
+    setupIntl(hooks);
 
     test('it renders', async function (assert) {
       await render(hbs`<ValidatedInput::Types::Date />`);


### PR DESCRIPTION
- fix django-date transform being weird with flatpickr (it ignored the timezone)
- made EOL Dates editable

Demo:

https://github.com/adfinis/Outdated/assets/110528300/25ca4f31-2e73-47ed-b3aa-1d5c0be89b4d

