### PR TITLE
fix(api): correctly order projects by most outdated version

### DIFF
--- a/api/outdated/outdated/views.py
+++ b/api/outdated/outdated/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Max
+from django.db.models import Min
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
@@ -8,13 +8,9 @@ from .tracking import Tracker
 
 
 class ProjectViewSet(ModelViewSet):
-    queryset = (
-        models.Project.objects.all()
-        .annotate(
-            latest_eol=Max("versioned_dependencies__release_version__end_of_life"),
-        )
-        .order_by("latest_eol")
-    )
+    queryset = models.Project.objects.annotate(
+        min_end_of_life=Min("versioned_dependencies__release_version__end_of_life")
+    ).order_by("min_end_of_life")
 
     serializer_class = serializers.ProjectSerializer
     filterset_class = filters.ProjectFilterSet


### PR DESCRIPTION
# Current
![image](https://github.com/adfinis/outdated/assets/110528300/558633ab-fd14-4a2f-b145-8b8d9dd7bd97)

# After fix
![image](https://github.com/adfinis/outdated/assets/110528300/c74ec103-9fb3-4f08-9c91-843dcf8e8dce)
