### PR TITLE
perf(ember): optimize lodash imports

### DIFF
--- a/ember/app/components/filter.gjs
+++ b/ember/app/components/filter.gjs
@@ -5,7 +5,7 @@ import Component from '@glimmer/component';
 import optional from 'ember-composable-helpers/helpers/optional';
 import PowerSelect from 'ember-power-select/components/power-select';
 import { or } from 'ember-truth-helpers';
-import { startCase } from 'lodash';
+import startCase from 'lodash/startCase';
 
 const Select = <template>
   <PowerSelect

--- a/ember/app/components/table.gjs
+++ b/ember/app/components/table.gjs
@@ -5,7 +5,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import formatDate from 'ember-intl/helpers/format-date';
 import { or } from 'ember-truth-helpers';
-import { startCase } from 'lodash';
+import startCase from 'lodash/startCase';
 
 const TableRow = <template>
   <tr>{{yield}}</tr>

--- a/ember/app/components/version-detailed.gjs
+++ b/ember/app/components/version-detailed.gjs
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import formatDate from 'ember-intl/helpers/format-date';
 import UkIcon from 'ember-uikit/components/uk-icon';
-import { startCase } from 'lodash';
+import startCase from 'lodash/startCase';
 
 import {
   ProjectCell,

--- a/ember/app/controllers/versions/index.js
+++ b/ember/app/controllers/versions/index.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { uniq } from 'lodash';
+import uniq from 'lodash/uniq';
 
 export default class VersionIndexController extends Controller {
   queryParams = ['status', 'dependency', 'version'];


### PR DESCRIPTION
fixes

> [!WARNING]
> ⠦ building... [@embroider/webpack][BABEL] Note: The code generator has deoptimised the styling of /home/arthurd/__all__/__dev__/__work__/outdated2/ember/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/lodash.js as it exceeds the max of 500KB.

and decreases bundle size by .1mb